### PR TITLE
corrected reported Issue #5 in comm hander.

### DIFF
--- a/octoprint_siocontrol/Connection.py
+++ b/octoprint_siocontrol/Connection.py
@@ -334,10 +334,10 @@ class Connection:
                             self._logger.debug(f"IO claimed ready for commands:{line}")
                             self.enableCommandQueue = True
 
-                        elif list[:2] == "IT":  # IO type List
+                        elif line[:2] == "IT":  # IO type List
                             self._logger.debug(f"IO Type list sent:{line}")
 
-                        elif list[:2] == "DG":  # Debug Message
+                        elif line[:2] == "DG":  # Debug Message
                             self._logger.debug(f"IO sent debug message:{line}")
 
                         else:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 plugin_identifier = "siocontrol"
 plugin_package = "octoprint_siocontrol"
 plugin_name = "SIO Control"
-plugin_version = "0.6.3"
+plugin_version = "0.6.4"
 plugin_description = "Adds a sidebar with on/off buttons for controling a SerialIO module. Integrates with PSU Control. Includes faliment runout and Emergency Stop input capabilites."
 plugin_author = "jcassel"
 plugin_author_email = "jcassel@softwaresedge.com"


### PR DESCRIPTION
This corrects an issue that could come up in the logs when restarting the SIO device and more so if the device has debug messages enabled.  Likely would cause a forced disconnect from the device based on too many unknown commands. 