### PR TITLE
Corrrected f(string) formatting syntax issue found in Issue #12.

### DIFF
--- a/octoprint_siocontrol/__init__.py
+++ b/octoprint_siocontrol/__init__.py
@@ -411,9 +411,7 @@ class SiocontrolPlugin(
                         states.append(pstate)
                 else:
                     if self.conn is not None and self.conn.is_connected() is True:
-                        self._logger.info(
-                            f"Pin number assigned to IO control{pin=} maybe out of range."
-                        )
+                        self._logger.info("Pin number assigned to IO control{} maybe out of range.".format(pin))
 
                     states.append("off")
             else:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 plugin_identifier = "siocontrol"
 plugin_package = "octoprint_siocontrol"
 plugin_name = "SIO Control"
-plugin_version = "0.6.5"
+plugin_version = "0.6.6"
 plugin_description = "Adds a sidebar with on/off buttons for controling a SerialIO module. Integrates with PSU Control. Includes faliment runout and Emergency Stop input capabilites."
 plugin_author = "jcassel"
 plugin_author_email = "jcassel@softwaresedge.com"


### PR DESCRIPTION
Corrected issue where Python below 3.10.x seems to generate a compile error when using f(sting) in caught error text output. 
Updated Version minor build number. 