### PR TITLE
Sub-PlugIn Capability Update. Inject and inspect serial commands, Hide show IO Status in Side bar

### DIFF
--- a/octoprint_siocontrol/static/js/siocontrol.js
+++ b/octoprint_siocontrol/static/js/siocontrol.js
@@ -120,17 +120,15 @@ $(function () {
 
         self.onSettingsShown = function () {
             self.sioConfigurations(self.settingsViewModel.settings.plugins.siocontrol.sio_configurations.slice(0));
-            //self.sioScriptAlignments(self.settingsViewModel.settings.plugins.siocontrol.sio_ScriptAlignments.slice(0));
             self.updateIconPicker();
         };
 
         self.onSettingsHidden = function () {
             self.sioConfigurations(self.settingsViewModel.settings.plugins.siocontrol.sio_configurations.slice(0));
-            //self.updateSioButtons();
         };
 
         self.addSioConfiguration = function () {
-            self.sioConfigurations.push({ pin: 0, icon: "fas fa-plug", name: "", active_mode: "active_out_high", default_state: "default_off", on_nav: 0 });
+            self.sioConfigurations.push({ pin: 0, icon: "fas fa-plug", name: "", active_mode: "active_out_high", default_state: "default_off", on_nav: 0,on_side:0 });
             self.updateIconPicker();
         };
 
@@ -172,6 +170,7 @@ $(function () {
                         active_mode: item.active_mode,
                         pin: item.pin,
                         on_nav: item.on_nav,
+                        on_side: item.on_side,
                     }
                 }));
 
@@ -183,6 +182,7 @@ $(function () {
                         active_mode: item.active_mode,
                         pin: item.pin,
                         on_nav: item.on_nav,
+                        on_side: item.on_side,
                     });
 
                     //removeClass("off").addClass("on");    

--- a/octoprint_siocontrol/templates/siocontrol_settings.jinja2
+++ b/octoprint_siocontrol/templates/siocontrol_settings.jinja2
@@ -124,15 +124,20 @@
                 <div class="control-group span12">   
                     <h4>IO Configuration</h4>
                     <div class="row-fluid">
-                    Add a row below for each IO point you wish to monitor or control.  Each row represents a button or switch. To add an Icon button to the navigation bar, check column [Nav?].
+                    Add a row below for each IO point you wish to monitor or control.
+                    Each row represents a digital IO point.
+                    To add an Icon button to the navigation bar, check column [Nav].
+                    To include the control on the side Nav, check column [Side].
+                    </p>
                     </div>
                     <div class="row-fluid">
                         <div class="span2"><h4>Icon</h4></div>
                         <div class="span2"><h4>Label</h4></div>
                         <div class="span1"><h4>IO#</h4></div>
-                        <div class="span3"><h4>Active As</h4></div>
+                        <div class="span2"><h4>Active As</h4></div>
                         <div class="span2"><h4>Default To</h4></div>
-                        <div class="span1"><h4>Nav?</h4></div>
+                        <div class="span1"><h4>Nav</h4></div>
+                        <div class="span2"><h4>Side</h4></div>
                         <div class="span1"><h4></h4></div>
                     </div>
 
@@ -150,7 +155,7 @@
                             <div class="input-prepend span1">
                                 <input class="siocontrol_InNumber" type="number" data-bind="value: pin"/>
                             </div>
-                            <div class="input-prepend span3">
+                            <div class="input-prepend span2">
                                 <select class="btn-group span12" data-bind="value: active_mode">
                                     <option value="active_out_low">Out_LOW</option>
                                     <option value="active_out_high">Out_HIGH</option>
@@ -165,7 +170,10 @@
                                 </select>
                             </div>
                             <div class="input-prepend span1">
-                                <input type="checkbox" class="input-block-level" data-bind="checked: on_nav" /> 
+                                <input type="checkbox" class="input-block-level" data-bind="checked: on_nav" />
+                            </div>
+                            <div class="input-prepend span1">
+                                <input type="checkbox" class="input-block-level" data-bind="checked: on_side" />
                             </div>
                             <div class="span1">
                                 <a title="Remove SIO Configuration" class="btn btn-danger" data-bind="click: $parent.removeSioConfiguration">

--- a/octoprint_siocontrol/templates/siocontrol_sidebar.jinja2
+++ b/octoprint_siocontrol/templates/siocontrol_sidebar.jinja2
@@ -1,6 +1,6 @@
 
 <div class="row-fluid" data-bind="foreach: sioButtons">
-    <div class="siocontrol-button-row row-fluid">
+    <div class="siocontrol-button-row row-fluid" data-bind="visible: on_side ==1">
         <div class="siocontrol-button-label span7">
             <i data-bind="class: icon"></i>
             <span data-bind="text: name"></span>

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from setuptools import setup
 plugin_identifier = "siocontrol"
 plugin_package = "octoprint_siocontrol"
 plugin_name = "SIO Control"
-plugin_version = "1.0.0"
-plugin_description = "Adds a sidebar with on/off buttons for controling a SerialIO module. Integrates with PSU Control. Includes faliment runout and Emergency Stop input capabilites."
+plugin_version = "1.0.1"
+plugin_description = "Serial IO Control. Integrates a micro controller to give native IO to your OctoPrint device"
 plugin_author = "jcassel"
 plugin_author_email = "jcassel@softwaresedge.com"
 plugin_url = "https://github.com/jcassel/OctoPrint-Siocontrol"
@@ -17,7 +17,6 @@ plugin_additional_packages = []
 plugin_ignored_packages = []
 additional_setup_parameters = {"python_requires": ">=3,<4"}
 ########################################################################################################################
-
 
 
 try:


### PR DESCRIPTION
Sub-PlugIn Update
- Added hook to allow sub-PlugIns to read serial comm coming from SIO Control board.
- Added remote call for sub-Plugins to send Commands to out Stream for the SIO Control board. 

UI Settings Update 
- added checkbox to add/remove items from the side navigation. 

Minor change
- Corrected the use of the serial port black list with the SIO Control port list.  This change allows you to put the port for the SIO Control in the black list and that way Octoprint will never try to connect to the SIO Controller thinking it is a printer. 



