### PR TITLE
Adding minimal support for is_api_protected

### DIFF
--- a/octoprint_siocontrol/__init__.py
+++ b/octoprint_siocontrol/__init__.py
@@ -259,6 +259,11 @@ class SiocontrolPlugin(
 
         return avalPorts
 
+    def is_api_protected(self):
+        """Require authentication for API access."""
+        return True # for now
+        
+
     def get_api_commands(self):
         return dict(
             turnSioOn=["id"],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 plugin_identifier = "siocontrol"
 plugin_package = "octoprint_siocontrol"
 plugin_name = "SIO Control"
-plugin_version = "1.0.2"
+plugin_version = "1.0.3"
 plugin_description = "Serial IO Control. Integrates a micro controller to give native IO to your OctoPrint device"
 plugin_author = "jcassel"
 plugin_author_email = "jcassel@softwaresedge.com"


### PR DESCRIPTION
Added needed method to handle up coming check for 'is_api_protected" as noted in [OctoPrint release notes: 1.11.2](https://github.com/OctoPrint/OctoPrint/releases/tag/1.11.2)

